### PR TITLE
fix(ci): add node setup to hugo deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,19 +9,31 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.124.1'
           extended: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build website
         run: hugo --minify
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public


### PR DESCRIPTION
The GitHub Pages deployment was failing because the workflow was missing steps to set up Node.js and install dependencies required for building assets with PostCSS/Tailwind CSS.

This change updates the `deploy.yml` workflow to:
- Add a step to set up Node.js (v20).
- Add a step to install npm dependencies using `npm ci`.
- Update existing actions (checkout, actions-hugo, actions-gh-pages) to their latest versions for improved stability and features.
- Configure checkout step to fetch submodules.